### PR TITLE
Modificaciones para adaptar su uso con apio 0.2.1.2

### DIFF
--- a/toolchain-simplez/sreset.py
+++ b/toolchain-simplez/sreset.py
@@ -2,10 +2,18 @@
 
 import serial
 import time
-
+import argparse
+import sys
 
 def main():
-    ser = serial.Serial('/dev/ttyUSB1', baudrate=115200)
+    parser = argparse.ArgumentParser(description="Send reset signal to Simplez from serial port")
+    parser.add_argument("-p", "--port", default='/dev/ttyUSB0', help="Port for serial terminal", action="store")
+    args = parser.parse_args()
+    try:
+        ser = serial.Serial(args.port, baudrate=115200)
+    except:
+        print("Error: Serial port not found: {}".format(args.port))
+        sys.exit(0)
 
     # -- Reset Simplez
     ser.setDTR(1)


### PR DESCRIPTION
Se establece al inicio del documento la codificación utf-8 para evitar
  problemas con tildes y caracteres no-ASCII.
Se genera una versión 'to_bytes' para descargar el programa en python 2.7
  (versión usada por apio 0.2.1.2).
Se agrega un nuevo parámetro --port para elegir el puerto serie.